### PR TITLE
Don't hard exit on send failures, but do notify the user

### DIFF
--- a/src/socketcan_bridge.cpp
+++ b/src/socketcan_bridge.cpp
@@ -56,7 +56,8 @@ void SocketCanBridge::send(const can_msgs::msg::Frame & msg) const
   RCLCPP_DEBUG_STREAM(logger_, "Sending " << msg);
   auto n = write(socket_, &frame, sizeof(frame));
   if (n < 0) {
-    throw std::system_error(errno, std::generic_category());
+    RCLCPP_ERROR_THROTTLE(
+      logger_, *clock_, 5000, "Error writing to the socket: %s (%d)", strerror(errno), errno);
   }
   RCLCPP_DEBUG(logger_, "Wrote %zd bytes to the socket", n);
 }


### PR DESCRIPTION
In a number of cases a send can fail, but if we then crash the node, all nodes in the container exit. 
Also if several CANbusses are in the same composable container.

If we simply log, the issue is clear (and might even recover), but the rest of the software at least stays operational.